### PR TITLE
Add Feature for blade @permission directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ You can also use Blade directives to display content based on the user's role:
 @endrole
 ```
 
+## Step 9: Displaying Content Based on Permissions
+
+You can also use Blade directives to display content based on the user's permissions:
+
+```php
+@permission('create-post')
+    {{ __('You can create a post') }}
+@endpermission
+```
+
 ## Example Seeder for Roles and Permissions
 
 Here's an example `RolePermissionSeeder` that seeds roles, permissions, and users:

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -70,5 +70,13 @@ class PermissionServiceProvider extends ServiceProvider
         Blade::directive('endrole', function () {
             return '<?php endif; ?>';
         });
+
+        Blade::directive('permission', function ($permission) {
+            return "<?php if(auth()->check() && auth()->user()->can({$permission})) : ?>";
+        });
+
+        Blade::directive('endpermission', function () {
+            return '<?php endif; ?>';
+        });
     }
 }


### PR DESCRIPTION
Hi there,

i'm using this in my own project, which is currently not yet published. But I wanted to make this usable for everyone.

### Feature

For Role there is a Blade directive, but for Permissions it is missing. Now you can use the following also for permissions:

```php
@permission('create-post')
    {{ __('You can create a post') }}
@endpermission
```

I also added the appropriate Documentation to the README.md